### PR TITLE
Adds pwb_prevent_brand_redirect filter hook

### DIFF
--- a/classes/class-perfect-woocommerce-brands.php
+++ b/classes/class-perfect-woocommerce-brands.php
@@ -916,6 +916,8 @@ class Perfect_Woocommerce_Brands {
    *  Better search experience
    */
   public function search_by_brand_name($query) {
+    if (apply_filters('pwb_prevent_brand_redirect', false, $query))
+      return;
 
     if (wp_doing_ajax())
       return;


### PR DESCRIPTION
The brand name search in Perfect WooCommerce Brands causes problems with Relevanssi search. Relevanssi can search brand names (and other taxonomies), and the redirect done by PWB blocks that.

A simple solution is to add a filter that can be used to disable the brand name search redirect in PWB (even simpler solution would be to just remove the filter that adds the PWB brand name search in the first place, but since you're using a class structure without assigning the class to a variable, it's quite hard to remove the filter).