### PR TITLE
Multilingual A-Z Listing shortcode

### DIFF
--- a/classes/shortcodes/class-pwb-az-listing.php
+++ b/classes/shortcodes/class-pwb-az-listing.php
@@ -8,7 +8,7 @@ class PWB_AZ_Listing_Shortcode {
 
   public static function shortcode( $atts ) {
 
-    $grouped_brands = get_transient('pwb_az_listing_cache');
+    $grouped_brands = get_transient( 'pwb_az_listing_cache_' . get_locale() );
 
     if ( ! $grouped_brands ) {
 
@@ -33,7 +33,7 @@ class PWB_AZ_Listing_Shortcode {
 
       }
 
-      set_transient( 'pwb_az_listing_cache', $grouped_brands, 43200 );//12 hours
+      set_transient( 'pwb_az_listing_cache_' . get_locale(), $grouped_brands, 43200 );//12 hours
 
     }
 


### PR DESCRIPTION
In multilingual context, users will want to translate the "Brand" custom taxonomy and have different brands per language. 

The issue is that the A-Z Listing shortcode is stored in a transient. This means that once the transient is saved, it will display the same result, whatever the language.

This PR allows to have on transient per locale, allowing the shortcode to work will all multilingual plugins.