### PR TITLE
Make sample relative URL relative to site-name

### DIFF
--- a/classes/admin/class-brands-custom-fields.php
+++ b/classes/admin/class-brands-custom-fields.php
@@ -38,7 +38,7 @@ class Brands_Custom_Fields {
     <div class="form-field pwb_brand_cont">
         <label for="pwb_brand_banner_link"><?php _e( 'Brand banner link', 'perfect-woocommerce-brands' ); ?></label>
         <input type="text" name="pwb_brand_banner_link" id="pwb_brand_banner_link" value="" >
-        <p><?php _e( 'This link should be relative to site url. Example: product/product-name', 'perfect-woocommerce-brands' ); ?></p>
+        <p><?php _e( 'This link should be relative to site url. Example: "/product/product-name"', 'perfect-woocommerce-brands' ); ?></p>
     </div>
 
     <?php wp_nonce_field( basename( __FILE__ ), 'pwb_nonce' ); ?>
@@ -109,7 +109,7 @@ class Brands_Custom_Fields {
         </th>
         <td>
           <input type="text" name="pwb_brand_banner_link" id="pwb_brand_banner_link" value="<?php echo $term_value_banner_link;?>" >
-          <p class="description"><?php _e( 'This link should be relative to site url. Example: product/product-name', 'perfect-woocommerce-brands' ); ?></p>
+          <p class="description"><?php _e( 'This link should be relative to site url. Example: "/product/product-name"', 'perfect-woocommerce-brands' ); ?></p>
           <div id="pwb_brand_banner_link_result"><?php echo wp_get_attachment_image ( $term_value_banner_link, array('90','90'), false );?></div>
         </td>
       </tr>


### PR DESCRIPTION
The current sample relative URL is relative to the current page, i.e. may point to different places depending on the permalink structure. It's much better to make relative links start with one slash "/". Such a URL will always be appended directly after the domain name. (Obviously, if a site is installed in a subdirectory, that directory name would need to be included in the link, too.)