### PR TITLE
Align rest api to WC standard functionality

### DIFF
--- a/classes/class-perfect-woocommerce-brands.php
+++ b/classes/class-perfect-woocommerce-brands.php
@@ -783,6 +783,7 @@ class Perfect_Woocommerce_Brands
       'query_var' => true,
       'public' => true,
       'show_admin_column' => true,
+      'show_in_rest' => true,
       'rewrite' => array(
         'slug' => apply_filters('pwb_taxonomy_rewrite', $new_slug),
         'hierarchical' => true,

--- a/classes/class-pwb-api-support.php
+++ b/classes/class-pwb-api-support.php
@@ -10,7 +10,7 @@ defined('ABSPATH') or die('No script kiddies please!');
 class PWB_API_Support extends WP_REST_Terms_Controller {
 
     private $namespaces = array( "wc/v1", "wc/v2", "wc/v3" );
-    protected $base = 'products/brands';
+    protected $base = 'brands';
     protected $taxonomy = 'pwb-brand';
 
     function __construct(){

--- a/classes/class-pwb-api-support.php
+++ b/classes/class-pwb-api-support.php
@@ -20,6 +20,7 @@ class PWB_API_Support extends WP_REST_Terms_Controller {
       add_action('rest_api_init', array($this, 'register_fields'));
 
       add_filter("rest_{$this->taxonomy}_collection_params",array($this,'modify_collection_params'),10,2);
+      add_filter( "woocommerce_rest_product_object_query", array( $this, 'brand_query_args' ), 10, 2 );
 
     }
     
@@ -261,6 +262,31 @@ class PWB_API_Support extends WP_REST_Terms_Controller {
      */
     private function add_brands($brands, $product){
         wp_set_post_terms($product->get_id(), $brands, "pwb-brand");
+    }
+
+    /**
+    * Add brands to product query args
+    * @param array $args
+    * @param array $request
+    */
+    public function brand_query_args( $args, $request ) {
+      // Filter product type by slug.
+      $tax_query = array();
+
+      // Filter product type by slug.
+      if ( ! empty( $request['brand'] ) ) {
+        $tax_query[] = array(
+          'taxonomy' => $this->taxonomy,
+          'field'    => 'slug',
+          'terms'    => $request['brand'],
+        );
+      }
+
+      if ( ! empty( $tax_query ) ) {
+        $args['tax_query'] = $tax_query;
+      }
+    
+      return $args;
     }
 
 }

--- a/classes/class-pwb-api-support.php
+++ b/classes/class-pwb-api-support.php
@@ -1,20 +1,23 @@
 <?php
 
 namespace Perfect_Woocommerce_Brands;
-use WP_Error, WP_REST_Server;
+use WP_REST_Server, WC_REST_Terms_Controller;
 
 defined('ABSPATH') or die('No script kiddies please!');
 
-class PWB_API_Support{
+class PWB_API_Support extends WC_REST_Terms_Controller {
 
     private $namespaces = array( "wc/v1", "wc/v2", "wc/v3" );
-    private $base = 'brands';
+    protected $base = 'brands';
+    protected $taxonomy = 'pwb-brand';
 
     function __construct(){
+
       add_action('rest_api_init', array($this, 'register_endpoints'));
       add_action('rest_api_init', array($this, 'register_fields'));
-    }
 
+    }
+    
     /**
      * Registers the endpoint for all possible $namespaces
      */
@@ -22,41 +25,170 @@ class PWB_API_Support{
         foreach( $this->namespaces as $namespace ) {
             register_rest_route($namespace, '/'.$this->base, array(
               array(
-                'methods'  => WP_REST_Server::READABLE,
-                'callback' => function () {
-                    return rest_ensure_response(
-                        Perfect_Woocommerce_Brands::get_brands()
-                    );
-                }
+                'methods'             => WP_REST_Server::READABLE,
+                'callback'            => array( $this, 'get_items' ),
+                'permission_callback' => array( $this, 'get_items_permissions_check' ),
+                'args'                => $this->get_collection_params(),
               ),
               array(
-                'methods'  => WP_REST_Server::CREATABLE,
-                'callback'  => array( $this, 'create_brand' )
+                'methods'             => WP_REST_Server::CREATABLE,
+                'callback'            => array( $this, 'create_item' ),
+                'permission_callback' => array( $this, 'create_item_permissions_check' ),
+                'args'                => array_merge( $this->get_endpoint_args_for_item_schema( WP_REST_Server::CREATABLE ), array(
+                  'name' => array(
+                    'description' => __( 'Brand name.', 'woocommerce' ),
+                    'required'    => true,
+                    'type'        => 'string',
+                  ),
+                ) ),
               ),
-              array(
-                'methods'   => WP_REST_Server::DELETABLE,
-                'callback'  => array( $this, 'delete_brand' )
-              )
-            ));
+              'schema' => array( $this, 'get_public_item_schema' ),
+            ) );
+
+
+            register_rest_route($namespace, '/' . $this->base . '/(?P<id>[\d]+)', array(
+                'args' => array(
+                  'id' => array(
+                    'description' => __( 'Unique identifier for the resource.', 'woocommerce' ),
+                    'type'        => 'integer',
+                  ),
+                ),
+                array(
+                  'methods'             => WP_REST_Server::READABLE,
+                  'callback'            => array( $this, 'get_item' ),
+                  'permission_callback' => array( $this, 'get_item_permissions_check' ),
+                  'args'                => array(
+                    'context'         => $this->get_context_param( array( 'default' => 'view' ) ),
+                  ),
+                ),
+                array(
+                  'methods'         => WP_REST_Server::EDITABLE,
+                  'callback'        => array( $this, 'update_item' ),
+                  'permission_callback' => array( $this, 'update_item_permissions_check' ),
+                  'args'            => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
+                ),
+                array(
+                  'methods'             => WP_REST_Server::DELETABLE,
+                  'callback'            => array( $this, 'delete_item' ),
+                  'permission_callback' => array( $this, 'delete_item_permissions_check' ),
+                  'args'                => array(
+                    'force' => array(
+                      'default'     => false,
+                      'type'        => 'boolean',
+                      'description' => __( 'Whether to bypass trash and force deletion.', 'woocommerce' ),
+                    ),
+                  ),
+                ),
+                'schema' => array( $this, 'get_public_item_schema' ),
+              ) );
         }
     }
 
-    public function delete_brand( $request ){
-      foreach( $request['brands'] as $brand ){
-        $delete_result = wp_delete_term( $brand, 'pwb-brand' );
-        if( is_wp_error( $delete_result ) ) return $delete_result;
-      }
-      return true;
+
+/**
+	 * Get the Brand schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+    public function get_item_schema() {
+      $schema = array(
+        '$schema'    => 'http://json-schema.org/draft-04/schema#',
+        'title'      => $this->taxonomy,
+        'type'       => 'object',
+        'properties' => array(
+          'id' => array(
+            'description' => __( 'Unique identifier for the object.', 'woocommerce' ),
+            'type'        => 'integer',
+            'context'     => array( 'view', 'edit' ),
+            'readonly'    => true,
+          ),
+          'name' => array(
+            'description' => __( 'Brand name.', 'woocommerce' ),
+            'type'        => 'string',
+            'context'     => array( 'view', 'edit' ),
+          ),
+          'slug' => array(
+            'description' => __( 'Brand slug.', 'woocommerce' ),
+            'type'        => 'string',
+            'context'     => array( 'view', 'edit' ),
+          ),
+          'description' => array(
+            'description' => __( 'Brand description.', 'woocommerce' ),
+            'type'        => 'string',
+            'context'     => array( 'view', 'edit' ),
+          ),
+          'parent' => array(
+            'description' => __( 'Brand parent.', 'woocommerce' ),
+            'type'        => 'integer',
+            'context'     => array( 'view', 'edit' ),
+          ),
+          'count' => array(
+            'description' => __( 'Number of published products for the brand.', 'woocommerce' ),
+            'type'        => 'integer',
+            'context'     => array( 'view', 'edit' ),
+            'readonly'    => true,
+          ),
+        ),
+      );
+  
+      return $this->add_additional_fields_schema( $schema );
     }
 
-    public function create_brand( $request ){
-      $new_brand = wp_insert_term( $request['name'], 'pwb-brand', array( 'slug' => $request['slug'], 'description' => $request['description'] ) );
-      if( !is_wp_error( $new_brand ) ){
-        return array('id' => $new_brand['term_id'], 'name' => $request['name'], 'slug' => $request['slug'], 'description' => $request['description']);
-      }else{
-        return $new_brand;
-      }
+    /**
+	 * Prepare a single brand output for response.
+	 *
+	 * @param WP_Term         $item    Term object.
+	 * @param WP_REST_Request $request Request instance.
+	 * @return WP_REST_Response
+	 */
+    public function prepare_item_for_response($item, $request) {
+      $data = array(
+        'term_id'     => (int) $item->term_id,
+        'name'        => $item->name,
+        'slug'        => $item->slug,
+        'term_group'  => $item->term_group,
+        'term_taxonomy_id' => $item->term_taxonomy_id,
+        'description' => $item->description,
+        'parent'      => $item->parent,
+        'count'       => (int) $item->count,
+        'filter'      => $item->filter,
+      );
+  
+      $context = ! empty( $request['context'] ) ? $request['context'] : 'view';
+      $data    = $this->add_additional_fields_to_object( $data, $request );
+      $data    = $this->filter_response_by_context( $data, $context );
+
+      $response = rest_ensure_response( $data );
+  
+  
+      /**
+       * Filter a term item returned from the API.
+       *
+       * Allows modification of the term data right before it is returned.
+       *
+       * @param WP_REST_Response  $response  The response object.
+       * @param object            $item      The original term object.
+       * @param WP_REST_Request   $request   Request used to generate the response.
+       */
+      return apply_filters( "woocommerce_rest_prepare_{$this->taxonomy}", $response, $item, $request );
     }
+
+    /**
+     * Add image fields to term item returned form the API
+     */
+    public function add_additional_fields_to_object($item, $request) {
+      
+      $brand_image_id = get_term_meta($item['term_id'], 'pwb_brand_image', true);
+      $brand_banner_id = get_term_meta($item['term_id'], 'pwb_brand_banner', true);
+      $item['brand_image'] = wp_get_attachment_image_src($brand_image_id);
+      $item['brand_banner'] = wp_get_attachment_image_src($brand_banner_id);
+      
+      return $item;
+
+    }
+
+   
+
 
     /**
      * Entry point for all rest field settings
@@ -76,6 +208,7 @@ class PWB_API_Support{
      * @return array
      */
     public function get_schema(){
+		
         return array(
             'description' => __('Product brands', 'perfect-woocommerce-brands'),
             'type' => 'array',
@@ -85,7 +218,7 @@ class PWB_API_Support{
             'context' => array("view", "edit")
         );
     }
-
+	
     /**
      * Returns all attached brands to a GET request to /products(/id)
      * @param $product

--- a/classes/class-pwb-api-support.php
+++ b/classes/class-pwb-api-support.php
@@ -73,7 +73,7 @@ class PWB_API_Support extends WC_REST_Terms_Controller {
                   'permission_callback' => array( $this, 'delete_item_permissions_check' ),
                   'args'                => array(
                     'force' => array(
-                      'default'     => false,
+                      'default'     => true,
                       'type'        => 'boolean',
                       'description' => __( 'Whether to bypass trash and force deletion.', 'woocommerce' ),
                     ),

--- a/classes/class-pwb-api-support.php
+++ b/classes/class-pwb-api-support.php
@@ -1,7 +1,7 @@
 <?php
 
 namespace Perfect_Woocommerce_Brands;
-use WP_REST_Server, WC_REST_Terms_Controller;
+use WP_Error, WP_REST_Server, WC_REST_Terms_Controller;
 
 defined('ABSPATH') or die('No script kiddies please!');
 
@@ -81,6 +81,17 @@ class PWB_API_Support extends WC_REST_Terms_Controller {
                 ),
                 'schema' => array( $this, 'get_public_item_schema' ),
               ) );
+
+            register_rest_route($namespace, '/' . $this->base . '/batch', array(
+                  array(
+                    'methods'             => WP_REST_Server::EDITABLE,
+                    'callback'            => array( $this, 'batch_items' ),
+                    'permission_callback' => array( $this, 'batch_items_permissions_check' ),
+                    'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
+                  ),
+                  'schema' => array( $this, 'get_public_batch_schema' ),
+                )
+              );
         }
     }
 
@@ -148,6 +159,7 @@ class PWB_API_Support extends WC_REST_Terms_Controller {
         'slug'        => $item->slug,
         'term_group'  => $item->term_group,
         'term_taxonomy_id' => $item->term_taxonomy_id,
+        'taxonomy'    => $this->taxonomy,
         'description' => $item->description,
         'parent'      => $item->parent,
         'count'       => (int) $item->count,
@@ -210,7 +222,7 @@ class PWB_API_Support extends WC_REST_Terms_Controller {
     public function get_schema(){
 		
         return array(
-            'description' => __('Product brands', 'perfect-woocommerce-brands'),
+            'description' => __('Product brands.', 'perfect-woocommerce-brands'),
             'type' => 'array',
             'items' => array(
                 "type" => "integer"


### PR DESCRIPTION
Hi,

I have been using this plugin to develop a new ecommerce website and really love it.  However, I have an integration (custom built) between the website and an epos system to manage products and orders etc.

As part of that integration, I needed to be able to have more functionality in the rest api to create/update/delete and search for brands by id (from the product detail) and by slug (used as key field to align epos and website).

This pull request updates the rest api functionality to align with standard WC api functionality in the following way:

1) Endpoint to return single brand --  /brands/[id]
2) Ability to search based on returned fields brands --  /brands?slug=xxx etc
3) Return only certain fields -- /brands?_fields=term_id, name
4) Support the api schema data -- /v3

It does, however, have a breaking change in that it now paginates (default 10 items, max 100) as is standard in wp, otherwise everyting is additional functionality and does not change existing.

Rather than have a custom version of this plugin, I thought it better to maybe include in the base repo and share with others.

Let me know if you're happy to merge or you would like any amends making.

Thanks
Mark