### PR TITLE
Add `permission_callback` callbacks as required for WordPress >= 5.5.0

### DIFF
--- a/classes/class-pwb-api-support.php
+++ b/classes/class-pwb-api-support.php
@@ -27,15 +27,22 @@ class PWB_API_Support{
                     return rest_ensure_response(
                         Perfect_Woocommerce_Brands::get_brands()
                     );
-                }
+                },
+                'permission_callback' => '__return_true',
               ),
               array(
                 'methods'  => WP_REST_Server::CREATABLE,
-                'callback'  => array( $this, 'create_brand' )
+                'callback'  => array( $this, 'create_brand' ),
+                'permission_callback' => function() {
+                    return current_user_can( 'manage_options' );
+                },
               ),
               array(
                 'methods'   => WP_REST_Server::DELETABLE,
-                'callback'  => array( $this, 'delete_brand' )
+                'callback'  => array( $this, 'delete_brand' ),
+                'permission_callback' => function() {
+                    return current_user_can( 'manage_options' );
+                },
               )
             ));
         }


### PR DESCRIPTION
Add `permission_callback` callbacks to silence warnings in logs and prevent arbitrary site visitors from creating/deleting brand records in the database.

Starting with WordPress 5.5.0 permission_callback must be specified for REST endpoints.