### PR TITLE
Admin shop order coupon with brand restriction fix.

### DIFF
--- a/classes/admin/class-pwb-coupon.php
+++ b/classes/admin/class-pwb-coupon.php
@@ -46,7 +46,7 @@
       $selected_brands = get_post_meta( $coupon->get_ID(), '_pwb_coupon_restriction', true );
       if( !empty( $selected_brands ) ){
         global $woocommerce;
-        $products = $woocommerce->cart->get_cart();
+        $products = is_admin() ? wc_get_order($_POST['order_id'])->get_items() : $woocommerce->cart->get_cart();
         foreach( $products as $product ) {
           $product_brands = wp_get_post_terms( $product['product_id'], 'pwb-brand', array( 'fields' => 'ids' ) );
           $valid_brands = array_intersect( $selected_brands, $product_brands );


### PR DESCRIPTION
Steps to recreate the bug.

1) Create a manual order for a customer in the admin (WooCommerce > Orders > Add Order). 
2) Then add your products to the order (obviously, a product that has a brand attached to it). 
3) Now try and apply a coupon (that has a brand restriction in place).

It will return a "Coupon not valid" js alert (when it is).

The reason is the **woocommerce_coupon_is_valid** filter, checks $woocommerce->cart->get_cart(). This returns empty as technically we don't have a cart (frontend), we are doing it through the admin screen. (Actually if you open a new tab and open your frontend then add the item to the cart, this will work in the admin)

So, if we are in the admin, we have to check differently **wc_get_order($_POST['order_id'])->get_items()**

