### PR TITLE
Add RTL option to short-code attributes for slick slider settings

### DIFF
--- a/lib/shortcodes/class-carousel.php
+++ b/lib/shortcodes/class-carousel.php
@@ -15,6 +15,7 @@ class Carousel {
 				'items'           => '10',
 				'items_to_show'   => '5',
 				'items_to_scroll' => '1',
+				'rtl'			  => 'false',
 				'image_size'      => 'thumbnail',
 				'autoplay'        => 'false',
 				'arrows'          => 'false',
@@ -55,6 +56,7 @@ class Carousel {
 			'slidesToScroll' => (int) self::$atts['items_to_scroll'],
 			'autoplay'       => ( 'true' === self::$atts['autoplay'] ) ? true : false,
 			'arrows'         => ( 'true' === self::$atts['arrows'] ) ? true : false,
+			'rtl'			 => ( 'true' === self::$atts['rtl'] ) ? true : false,
 		);
 
 		return htmlspecialchars( json_encode( $slick_settings ), ENT_QUOTES, 'UTF-8' );

--- a/lib/shortcodes/class-product-carousel.php
+++ b/lib/shortcodes/class-product-carousel.php
@@ -19,6 +19,7 @@ class Product_Carousel {
 				'products_to_scroll' => '1',
 				'autoplay'           => 'false',
 				'arrows'             => 'false',
+				'rtl'				 => 'false',
 			),
 			$atts,
 			'pwb-product-carousel'
@@ -52,6 +53,7 @@ class Product_Carousel {
 			'slidesToScroll' => (int) self::$atts['products_to_scroll'],
 			'autoplay'       => ( 'true' === self::$atts['autoplay'] ) ? true : false,
 			'arrows'         => ( 'true' === self::$atts['arrows'] ) ? true : false,
+			'rtl'     		 => ( 'true' === self::$atts['rtl'] ) ? true : false,
 		);
 
 		return htmlspecialchars( json_encode( $slick_settings ), ENT_QUOTES, 'UTF-8' );


### PR DESCRIPTION
Hello,
This PR adds RTL attributes to carousels' shortcodes to make the plugin support RTL language websites like Arabic,.
the short-code should be something like this to support RTL 

`[pwb-carousel  autoplay="true" rtl="true"]`

The RTL attribute is passed to [Slick slider setting](https://kenwheeler.github.io/slick/#:~:text=Vertical%20swipe%20mode-,rtl,-boolean) to let the carousel work smoothly on RTL websites.

